### PR TITLE
link DOIs to preferred resolver

### DIFF
--- a/src/front/abstract.tex
+++ b/src/front/abstract.tex
@@ -11,7 +11,7 @@ The abstract of this thesis.
 	\noac{ISBN} & \thesisISBN \\
 	\noac{ISSN} & \href{http://opc4.kb.nl/DB=1/SET=2/TTL=1/CMD?ACT=SRCHA&IKT=1007&SRT=YOP&TRM=\thesisISSN}{\thesisISSN}; %
 		\acs*{CTIT} Ph.D.\ Thesis Series No.\ \thesisCTITnr \\
-	\noac{DOI}  & \href{http://dx.doi.org/\thesisDOI}{\thesisDOI} \\
+	\noac{DOI}  & \href{https://doi.org/\thesisDOI}{\thesisDOI} \\
 	\end{tabular}%
 \fi
 

--- a/src/front/colophon.tex
+++ b/src/front/colophon.tex
@@ -79,7 +79,7 @@
 				\noac{ISBN} & \thesisISBN \\
 				\noac{ISSN} & \href{http://opc4.kb.nl/DB=1/SET=2/TTL=1/CMD?ACT=SRCHA&IKT=1007&SRT=YOP&TRM=\thesisISSN}{\thesisISSN}; %
 					\acs*{CTIT} Ph.D.\ Thesis Series No.\ \thesisCTITnr \\
-				\noac{DOI}  & \href{http://dx.doi.org/\thesisDOI}{\thesisDOI} \\
+				\noac{DOI}  & \href{https://doi.org/\thesisDOI}{\thesisDOI} \\
 				\end{tabular}%
 			\end{minipage}\\
 		\end{tabular}%

--- a/src/template/phdthesis.cls
+++ b/src/template/phdthesis.cls
@@ -393,7 +393,7 @@
 	%citebordercolor={0.5 0.5 1}
 }
 
-\newcommand*{\doi}[1]{\href{http://dx.doi.org/\detokenize{#1}}{doi: \detokenize{#1}}}
+\newcommand*{\doi}[1]{\href{https://doi.org/\detokenize{#1}}{doi: \detokenize{#1}}}
 
 %% ?
 \let\figref\fref % use \figref for memoirs \fref


### PR DESCRIPTION
Hello!

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). This PR implements that recommendation by changing the code that generates new DOI links.

Cheers :-)